### PR TITLE
Simplify game design

### DIFF
--- a/examples/start.ml
+++ b/examples/start.ml
@@ -1,28 +1,24 @@
+[@@@warning "-32"]
+
 open Roguetype_lib
+open! Generic
+open! Rules
 
-open Game.Lvl1
+module Lvl1 = struct
+  include Game.Lvl1
 
-let start = []
+  type p = Game.player_start
 
-let (=>) l x = x :: l
-
-let v = start => D => D => D => R => R => D  => R  => R
-        => U => U => U => U => U => U => U => U => Gate
-
-module Trace_1 = struct
-  type lvl = Game.Lvl1.t
-  type p= Game.player_start
-  type 'a path = 'a Game.Lvl1.path
-  let trace = v
+  let trace =
+    start => D => D => D => R => R => D => R => R => U => U => U => U => U => U
+    => U => U => Gate
 end
 
-module L2 = Game.Lvl2(Trace_1)
-open L2
+module Lvl2 = struct
+  include Game.Lvl2 (Lvl1)
 
-let[@warning "-32"] start_2 = []
+  (* type p = < health : R.four ; inventory : Inventory.none > *)
 
-(*
-let w = v
-        => R => R => D => R => R
-        => U => U => U => U => U => U => U => U => G
-*)
+  (* let trace = *)
+  (*   start => R => R => D => R => R => U => U => U => U => U => U => U => U => G *)
+end

--- a/lib/game.ml
+++ b/lib/game.ml
@@ -47,7 +47,7 @@ module Short_cases = struct
 end
 
 module Lvl1 = struct
-  type t type l = t
+  type t type lvl = t
   open Short_cases
   type world = (
     (a, f, f, t, f, f, f, t, g) row,
@@ -61,12 +61,14 @@ module Lvl1 = struct
     (e, t, f, f, f, t, f, f, f) row
   ) grid
 
-  type start = <world:world; player:player_start; lvl:l; init:player_turn >
+  type start = <world:world; player:player_start; lvl:lvl; init:player_turn >
 
   type _ path =
     | []: start path
     | (::): ('a -> 'b) move * 'a path -> 'b path
 
+  let start = []
+  let ( => ) l x = x :: l
 end
 
 module type clear = sig
@@ -79,7 +81,7 @@ end
 module Lvl2(X: clear with type 'a path = 'a Lvl1.path) =
 struct
 
-  type t type l = t
+  type t type lvl = t
   open Short_cases
   type world = (
     (f, f, f, f, f, f, m, m, g) row,
@@ -92,18 +94,21 @@ struct
     (m, k, m, m, m, m, m, m, f) row,
     (m, f, f, f, f, f, f, f, f) row
   ) grid
-  type start = <world:world; player:X.p; lvl:l; init:player_turn >
+  type start = <world:world; player:X.p; lvl:lvl; init:player_turn >
 
   type _ path =
     | []: start path
     | (::): ('a -> 'b) move * 'a path -> 'b path
+
+  let start = []
+  let ( => ) l x = x :: l
 end
 
 
 module Lvl3(L1: clear with type 'a path = 'a Lvl1.path)(X: clear with type 'a path = 'a Lvl2(L1).path) =
 struct
 
-  type t type l = t
+  type t type lvl = t
   open Short_cases
   type world = (
     (f , f , f , f , f , ko, f , f , f ) row,
@@ -116,11 +121,14 @@ struct
     (t , t , t , t , go, t , t , t , f ) row,
     (g , f , go, f , f , ko, f , f , f ) row
   ) grid
-  type start = <world:world; player:X.p; lvl:l; init:player_turn >
+  type start = <world:world; player:X.p; lvl:lvl; init:player_turn >
 
   type _ path =
     | []: start path
     | (::): ('a -> 'b) move * 'a path -> 'b path
+
+  let start = []
+  let ( => ) l x = x :: l
 end
 
 
@@ -130,7 +138,7 @@ module Lvl4
     (X: clear with type 'a path = 'a Lvl3(L1)(L2).path) =
 struct
 
-  type t type l = t
+  type t type lvl = t
   open Short_cases
   type world = (
    (d , f, f, m, k, f, f, m, g) row,
@@ -144,11 +152,14 @@ struct
    (p, d, f, m, f, f, f, go, f) row
   ) grid
 
-  type start = <world:world; player:X.p; lvl:l; init:player_turn >
+  type start = <world:world; player:X.p; lvl:lvl; init:player_turn >
 
   type _ path =
     | []: start path
     | (::): ('a -> 'b) move * 'a path -> 'b path
+
+  let start = []
+  let ( => ) l x = x :: l
 end
 
 module Lvl5
@@ -158,7 +169,7 @@ module Lvl5
     (X: clear with type 'a path = 'a Lvl4(L1)(L2)(L3).path)
 = struct
 
-  type t type l = t
+  type t type lvl = t
   open Short_cases
   type world = (
     (m, m, k, m, f, oc, og, tr, c) row,
@@ -171,11 +182,14 @@ module Lvl5
     (f, f, m, p, m, f, f, m, f) row,
     (f, f, f, d, m, f, f, m, e) row
   ) grid
-  type start = <world:world; player:X.p; lvl:l; init:player_turn >
+  type start = <world:world; player:X.p; lvl:lvl; init:player_turn >
 
   type _ path =
     | []: start path
     | (::): ('a -> 'b) move * 'a path -> 'b path
+
+  let start = []
+  let ( => ) l x = x :: l
 end
 
 module Lvl6
@@ -186,7 +200,7 @@ module Lvl6
     (X: clear with type 'a path = 'a Lvl5(L1)(L2)(L3)(L4).path)
 = struct
 
-  type t type l = t
+  type t type lvl = t
   open Short_cases
   type world = (
     (t, t, t, t, t, t, tr, t, f) row,
@@ -199,11 +213,14 @@ module Lvl6
     (f, t, t, t, t, oc, t, t, t) row,
     (f, f, ko, f, f, f, f, ko, a) row
   ) grid
-  type start = <world:world; player:X.p; lvl:l; init:player_turn >
+  type start = <world:world; player:X.p; lvl:lvl; init:player_turn >
 
   type _ path =
     | []: start path
     | (::): ('a -> 'b) move * 'a path -> 'b path
+
+  let start = []
+  let ( => ) l x = x :: l
 end
 
 module Lvl7
@@ -215,7 +232,7 @@ module Lvl7
     (X: clear with type 'a path = 'a Lvl6(L1)(L2)(L3)(L4)(L5).path)
 = struct
 
-  type t type l = t
+  type t type lvl = t
   open Short_cases
   type world = (
     (p, d, f, m, m, k, f, m, m) row,
@@ -228,11 +245,14 @@ module Lvl7
     (r, m, f, m, e, m, f, m, d) row,
     (dr, f, f, m, s, og, f, m, g) row
   ) grid
-  type start = <world:world; player:X.p; lvl:l; init:player_turn >
+  type start = <world:world; player:X.p; lvl:lvl; init:player_turn >
 
   type _ path =
     | []: start path
     | (::): ('a -> 'b) move * 'a path -> 'b path
+
+  let start = []
+  let ( => ) l x = x :: l
 end
 
 module Lvl8
@@ -246,7 +266,7 @@ module Lvl8
 
 = struct
 
-  type t type l = t
+  type t type lvl = t
   open Short_cases
   type world = (
     (f, m, m, m, f, oc, f, f, f) row,
@@ -259,11 +279,14 @@ module Lvl8
     (dr, m, m, m, f, m, f, m, f) row,
     (f, f, f, f, f, m, f, f, f ) row
   ) grid
-  type start = <world:world; player:X.p; lvl:l; init:player_turn >
+  type start = <world:world; player:X.p; lvl:lvl; init:player_turn >
 
   type _ path =
     | []: start path
     | (::): ('a -> 'b) move * 'a path -> 'b path
+
+  let start = []
+  let ( => ) l x = x :: l
 
   let win (_:<victory:yes> path) = exit 0
 end


### PR DESCRIPTION
Player can now use '=>' without forging it themselves and without risk of getting the recipe wrong.

The side quest of writing the runes on the gate before entering it is made optional. The gate opens with the basic spell 'include'.

I've done this to the first 3 levels only as I'm not sure it's right. I'll do it to the other levels if you think it's a good idea.